### PR TITLE
fix: add dynamic keys for environments for s3 bucket

### DIFF
--- a/.cicd/terraform/compute/backend.tf
+++ b/.cicd/terraform/compute/backend.tf
@@ -6,7 +6,7 @@ terraform {
     }
     region                      = "fra1"
     bucket                      = "grimwaves-terraform-state"
-    key                         = "compute/terraform.tfstate"
+    # key will be passed dynamically through -backend-config
     
     # Disable AWS-specific validations for DigitalOcean Spaces
     skip_credentials_validation = true

--- a/.cicd/terraform/compute/main.tf
+++ b/.cicd/terraform/compute/main.tf
@@ -1,5 +1,9 @@
 provider "digitalocean" {
   token = var.do_token
+  
+  # Configure Spaces credentials
+  spaces_access_id  = var.spaces_access_key_id
+  spaces_secret_key = var.spaces_secret_access_key
 }
 
 locals {

--- a/.cicd/terraform/compute/variables.tf
+++ b/.cicd/terraform/compute/variables.tf
@@ -122,3 +122,15 @@ variable "emergency_ssh_access" {
   type        = bool
   default     = false
 }
+
+variable "spaces_access_key_id" {
+  description = "DigitalOcean Spaces access key ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "spaces_secret_access_key" {
+  description = "DigitalOcean Spaces secret access key"
+  type        = string
+  sensitive   = true
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,14 +364,16 @@ jobs:
           fi
 
       - name: Fix permissions for Trivy cache
+        if: always()
         run: |
-          sudo chown -R $USER:$USER .cache/trivy
+          sudo chown -R $USER:$USER .cache/trivy || true
 
       - name: Upload vulnerability scan results
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
-          name: dev-images-vulnerability-scan
+          name: docker-images-vulnerability-scan
           path: .cache/trivy/
           retention-days: 7
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,10 @@ jobs:
           # Credentials for DigitalOcean Spaces (S3-compatible backend)
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: terraform init
+        run: |
+          # Create backend config with environment-specific key
+          echo "key=compute/${{ needs.prepare.outputs.environment }}/terraform.tfstate" > backend.conf
+          terraform init -backend-config=backend.conf
 
       - name: Debug Backend Configuration
         working-directory: .cicd/terraform/compute
@@ -167,9 +170,12 @@ jobs:
           TF_VAR_domain_name: ${{ vars.DEPLOYMENT_DOMAIN || '' }}
           # SSH port configuration - use secret or default
           TF_VAR_ssh_port: ${{ secrets.SSH_PORT || '2222' }}
-          # Credentials for DigitalOcean Spaces (S3-compatible backend)
+          # Credentials for DigitalOcean Spaces (S3-compatible backend and Spaces resources)
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Pass DigitalOcean Spaces credentials for Terraform provider
+          SPACES_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          SPACES_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           # Debug SSH public key (first 50 chars for security)
           echo "=== SSH Public Key Debug ==="
@@ -183,6 +189,9 @@ jobs:
             exit 1
           fi
           
+          # Ensure backend config exists for plan
+          echo "key=compute/${{ needs.prepare.outputs.environment }}/terraform.tfstate" > backend.conf
+          
           # Use dynamic IP for CI/CD runner instead of 0.0.0.0/0
           terraform plan \
             -var="do_token=${{ secrets.DO_TOKEN }}" \
@@ -194,6 +203,8 @@ jobs:
             -var="vpn_ip=${{ secrets.VPN_IP }}" \
             -var="emergency_ssh_access=true" \
             -var="vault_server_ip=${{ secrets.VAULT_SERVER_IP }}" \
+            -var="spaces_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}" \
+            -var="spaces_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
             -out=tfplan
 
       - name: Terraform Apply
@@ -202,7 +213,10 @@ jobs:
           # Credentials for DigitalOcean Spaces (S3-compatible backend)
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: terraform apply -auto-approve tfplan
+        run: |
+          # Ensure backend config exists for apply
+          echo "key=compute/${{ needs.prepare.outputs.environment }}/terraform.tfstate" > backend.conf
+          terraform apply -auto-approve tfplan
 
       - name: Verify State File Upload
         working-directory: .cicd/terraform/compute
@@ -228,24 +242,25 @@ jobs:
             --endpoint-url=https://fra1.digitaloceanspaces.com \
             --recursive || echo "❌ Failed to list bucket contents"
           
-          # Check specifically for our state file
-          if aws s3 ls s3://grimwaves-terraform-state/compute/terraform.tfstate \
+          # Check specifically for our environment-specific state file
+          STATE_FILE_PATH="compute/${{ needs.prepare.outputs.environment }}/terraform.tfstate"
+          if aws s3 ls s3://grimwaves-terraform-state/$STATE_FILE_PATH \
             --endpoint-url=https://fra1.digitaloceanspaces.com; then
-            echo "✅ State file found in bucket!"
+            echo "✅ State file found in bucket: $STATE_FILE_PATH"
             
             # Get file size
-            aws s3 ls s3://grimwaves-terraform-state/compute/terraform.tfstate \
+            aws s3 ls s3://grimwaves-terraform-state/$STATE_FILE_PATH \
               --endpoint-url=https://fra1.digitaloceanspaces.com \
               --human-readable --summarize
           else
-            echo "❌ CRITICAL: State file NOT found in bucket!"
+            echo "❌ CRITICAL: State file NOT found in bucket: $STATE_FILE_PATH"
             echo "This indicates Terraform did not upload state to remote backend"
             exit 1
           fi
           
           # Try to read the state file to verify it contains our resources
           echo "=== Verifying state file contents ==="
-          aws s3 cp s3://grimwaves-terraform-state/compute/terraform.tfstate - \
+          aws s3 cp s3://grimwaves-terraform-state/$STATE_FILE_PATH - \
             --endpoint-url=https://fra1.digitaloceanspaces.com \
             | jq '.resources[] | select(.type == "digitalocean_project") | .instances[0].attributes.name' \
             || echo "❌ Failed to read/parse state file"
@@ -258,6 +273,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          # Ensure backend config exists for outputs
+          echo "key=compute/${{ needs.prepare.outputs.environment }}/terraform.tfstate" > backend.conf
           echo "droplet_ip=$(terraform output -raw droplet_ipv4)" >> $GITHUB_OUTPUT
           echo "app_url=$(terraform output -raw app_url)" >> $GITHUB_OUTPUT
           echo "ssh_port=$(terraform output -raw ssh_port)" >> $GITHUB_OUTPUT

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -83,7 +83,10 @@ jobs:
           # Credentials for DigitalOcean Spaces (S3-compatible backend)
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: terraform init
+        run: |
+          # Create backend config with environment-specific key
+          echo "key=compute/${{ needs.validate.outputs.environment }}/terraform.tfstate" > backend.conf
+          terraform init -backend-config=backend.conf
 
       - name: Check Current State
         working-directory: .cicd/terraform/compute

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -85,7 +85,7 @@ certificatesResolvers:
         entryPoint: web
 ```
 
-And update the `docker-compose.prod.yml` file to use this resolver.
+And update the `docker-compose.production.yml` file to use this resolver.
 
 ## Deployment
 


### PR DESCRIPTION
- Correct the filename from docker-compose.prod.yml to docker-compose.production.yml in DEPLOYMENT.md
- Modify backend.tf to pass the key dynamically through -backend-config
- Add Spaces credentials configuration in main.tf
- Introduce new variables for Spaces access key ID and secret access key in variables.tf
- Update CI/CD workflows to ensure proper handling of environment-specific state files and Spaces credentials during Terraform operations